### PR TITLE
Add Navigation Functionality to Curio Logo 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3981,25 +3981,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.3.tgz",
-      "integrity": "sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.1.3",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "5.17.0",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.17.0.tgz",
@@ -16222,12 +16203,6 @@
       "resolved": "https://registry.npmjs.org/scmp/-/scmp-2.1.0.tgz",
       "integrity": "sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q=="
     },
-    "node_modules/sdp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.0.tgz",
-      "integrity": "sha512-d7wDPgDV3DDiqulJjKiV2865wKsJ34YI+NDREbm+FySq6WuKOikwyNQcm+doLAZ1O6ltdO0SeKle2xMpN3Brgw==",
-      "peer": true
-    },
     "node_modules/select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -18338,19 +18313,6 @@
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "engines": {
         "node": ">=0.8.x"
-      }
-    },
-    "node_modules/webrtc-adapter": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-8.2.3.tgz",
-      "integrity": "sha512-gnmRz++suzmvxtp3ehQts6s2JtAGPuDPjA1F3a9ckNpG1kYdYuHWYpazoAnL9FS5/B21tKlhkorbdCXat0+4xQ==",
-      "peer": true,
-      "dependencies": {
-        "sdp": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.10.0"
       }
     },
     "node_modules/websocket-driver": {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 // import { Header, Image } from 'semantic-ui-react'
 import Curiologo from '../assets/images/Csmall.png'
 import './header.css';
+import { Link ,BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 
 const HeaderCurio = () => {
   //Used to toggle the hamburger menu
@@ -9,15 +10,19 @@ const HeaderCurio = () => {
 
   return (
     <>
-
       <div className='curio__header'>
+        {/* Wrapping the Link components within the Router component */}
+      <Router>
+        {/* Logo linking to the homepage */}
+        <Link to='/'>
         <div className='gradient__text'>
           <h1>
-            <img src={Curiologo} alt='Curio' className='curio__icon' />
+              <img src={Curiologo} alt='Curio' className='curio__icon' />
             <span>URIO</span>
           </h1>
           <p className='curio__tag'><b>Your Video Translator :)</b></p>
         </div>
+        </Link>
 
         <div className='curio__sign'>
           <p>About</p>
@@ -25,22 +30,26 @@ const HeaderCurio = () => {
           <button type='button'>Sign Up</button>
 
         </div>
+        </Router>
       </div>
       {/*Added a mobile version
      Screen width is < 768px above is disabled and below is triggered
      Added hamburger menu and generic options for the menu
      */}
-      { }
       <div className='curio__header-m'>
+        {/* Wrapping the Link components within the Router component */}
+      <Router>
+         {/* Logo linking to the homepage */}
+      <Link to='/'>
         <div className=' gradient__text  gradient__text-m'>
           <h1>
-            <img src={Curiologo} alt='Curio' className='curio__icon' />
+              <img src={Curiologo} alt='Curio' className='curio__icon' />
             <span>URIO</span>
           </h1>
           <p className='curio__tag'><b>Your Video Translator :)</b></p>
 
         </div>
-
+        </Link>
         <button onClick={() => { setTriggerMenu(!triggerMenu) }} className='hamburger-m' type="button">
           {/*
           This is the hamburger line icon
@@ -59,7 +68,7 @@ const HeaderCurio = () => {
           </div>
 
         </button>
-
+        </Router>
       </div>
       {/*
     The menu of the hamburger 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 // import { Header, Image } from 'semantic-ui-react'
 import Curiologo from '../assets/images/Csmall.png'
 import './header.css';
-import { Link ,BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import { Link ,BrowserRouter as Router } from 'react-router-dom';
 
 const HeaderCurio = () => {
   //Used to toggle the hamburger menu
@@ -11,14 +11,14 @@ const HeaderCurio = () => {
   return (
     <>
 
-      <div className='curio__header'>
+      <div className="curio__header">
           {/* Wrapping the Link components within the Router component */}
       <Router>
          {/* Logo linking to the homepage */}
-        <Link to='/'>
-        <div className='gradient__text'>
+        <Link to="/" style={{ textDecoration: "none" }}>
+        <div className="gradient__text">
           <h1>
-            <img src={Curiologo} alt='Curio' className='curio__icon' />
+            <img src={Curiologo} alt="Curio" className="curio__icon" />
             <span>URIO</span>
           </h1>
           <p className="curio__tag">
@@ -39,14 +39,14 @@ const HeaderCurio = () => {
      Added hamburger menu and generic options for the menu
      */}
       { }
-      <div className='curio__header-m'>
+      <div className="curio__header-m">
          {/* Wrapping the Link components within the Router component */}
          <Router>
           {/* Logo linking to the homepage */}
-          <Link to='/'>
-        <div className=' gradient__text  gradient__text-m'>
+          <Link to="/" style={{ textDecoration: "none" }}>
+        <div className=" gradient__text  gradient__text-m">
           <h1>
-            <img src={Curiologo} alt='Curio' className='curio__icon' />
+            <img src={Curiologo} alt="Curio" className="curio__icon" />
             <span>URIO</span>
           </h1>
           <p className="curio__tag">
@@ -55,7 +55,7 @@ const HeaderCurio = () => {
         </div>
         </Link>
 
-        <button onClick={() => { setTriggerMenu(!triggerMenu) }} className='hamburger-m' type="button">
+        <button onClick={() => { setTriggerMenu(!triggerMenu) }} className="hamburger-m" type="button">
           {/*
           This is the hamburger line icon
           First one is when it's off


### PR DESCRIPTION
Changes implemented:
- Wrapped the Curio logo in `HeaderCurio` with the React Router's `Link` component.
- Ensured the logo acts as a link directing users to the homepage.
